### PR TITLE
totalTimeNotWriting fix

### DIFF
--- a/src/EndOfSprintStatsModal.ts
+++ b/src/EndOfSprintStatsModal.ts
@@ -59,12 +59,12 @@ export default class EndOfSprintStatsModal extends Modal {
 				text.setValue(`${secondsToHumanize(this.sprintRunStat.longestStretchNotWriting)}`)
 				text.setDisabled(true)
 			})
-		// new Setting(contentEl)
-		// 	.setName("Total Time Not Writing")
-		// 	.addText((text) => {
-		// 		text.setValue(`${secondsToHumanize(this.sprintRunStat.totalTimeNotWriting)}`)
-		// 		text.setDisabled(true)
-		// 	})
+		new Setting(contentEl)
+		 	.setName("Total Time Not Writing")
+		 	.addText((text) => {
+		 		text.setValue(`${secondsToHumanize(this.sprintRunStat.totalTimeNotWriting)}`)
+		 		text.setDisabled(true)
+		 	})
 	}
 
 	onClose() {

--- a/src/SprintRun.ts
+++ b/src/SprintRun.ts
@@ -86,14 +86,19 @@ export default class SprintRun {
 		return wordCountDisplay >= 0 ? wordCountDisplay : 0
 	}
 
-	typingUpdate(contents: string, filepath: string) {
-		const secondsSinceLastWord = Date.now() - this.lastWordTime
+	updateNotWriting(updateTime : number) {
+		const secondsSinceLastWord = Math.floor((updateTime - this.lastWordTime)/1000) // don't count < 1 second gaps
 
 		if (secondsSinceLastWord > this.longestStretchNotWriting) {
 			this.longestStretchNotWriting = secondsSinceLastWord
 		}
 		this.totalTimeNotWriting += secondsSinceLastWord
-		this.lastWordTime = Date.now()
+	}
+
+	typingUpdate(contents: string, filepath: string) {
+		const currentNow = Date.now()
+		this.updateNotWriting(currentNow)
+		this.lastWordTime = currentNow
 		this.wordCount = getWordCount(contents)
 
 		this.wordsPerMinute[this.latestMinute].now = (this.getWordCountDisplay() - this.wordsPerMinute[this.latestMinute].previous)
@@ -180,6 +185,7 @@ export default class SprintRun {
 			if (this.millisecondsLeft <= 0 && this.sprintStarted) {
 				this.sprintStarted = false
 				this.sprintComplete = true
+				this.updateNotWriting(currentNow)
 				window.clearInterval(this.sprintInterval)
 
 				// DEBUG
@@ -196,6 +202,8 @@ export default class SprintRun {
 	 */
 	stopSprint(): SprintRunStat {
 		if (this.sprintStarted) {
+			// this must be called before we getStats(), otherwise the data will be missing
+			this.updateNotWriting(Date.now())
 			const stats = this.getStats()
 
 			this.endOfSprintCallback(stats)
@@ -224,8 +232,8 @@ export default class SprintRun {
 			averageWordsPerMinute: averageWordsPerMinute,
 			yellowNotices: this.yellowNoticeCount,
 			redNotices: this.redNoticeCount,
-			longestStretchNotWriting: Math.ceil(this.longestStretchNotWriting / 1000),
-			totalTimeNotWriting: Math.ceil(this.totalTimeNotWriting / 1000),
+			longestStretchNotWriting: Math.ceil(this.longestStretchNotWriting),
+			totalTimeNotWriting: Math.ceil(this.totalTimeNotWriting),
 			elapsedMilliseconds: this.elapsedMilliseconds,
 			created: this.created,
 		} as SprintRunStat

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ export default class WordSprintPlugin extends Plugin {
 				statsText += `Yellow Notices: ${stats.yellowNotices}\n`
 				statsText += `Red Notices: ${stats.redNotices}\n`
 				statsText += `Longest Stretch Not Writing: ${secondsToHumanize(stats.longestStretchNotWriting)}\n`
-				// statsText += `Total Time Not Writing: ${secondsToHumanize(stats.totalTimeNotWriting)}\n`
+				statsText += `Total Time Not Writing: ${secondsToHumanize(stats.totalTimeNotWriting)}\n`
 
 				editor.replaceSelection(statsText)
 			}


### PR DESCRIPTION
This should fix the totalTimeNotWriting. This could probably further be tweaked by making a threshold match the yellow warning, but I think ignore stops of less than 1 second is sufficient to start. Now that secondsSinceLastWord is actually in seconds, and longestStretchNotWriting and totalTimeNotWriting are in seconds, no need to divide by 1000 in for SprintRunStat.