### PR TITLE
Update SprintRun.ts

### DIFF
--- a/src/SprintRun.ts
+++ b/src/SprintRun.ts
@@ -232,8 +232,8 @@ export default class SprintRun {
 			averageWordsPerMinute: averageWordsPerMinute,
 			yellowNotices: this.yellowNoticeCount,
 			redNotices: this.redNoticeCount,
-			longestStretchNotWriting: Math.ceil(this.longestStretchNotWriting),
-			totalTimeNotWriting: Math.ceil(this.totalTimeNotWriting),
+			longestStretchNotWriting: this.longestStretchNotWriting,
+			totalTimeNotWriting: this.totalTimeNotWriting,
 			elapsedMilliseconds: this.elapsedMilliseconds,
 			created: this.created,
 		} as SprintRunStat


### PR DESCRIPTION
No need for Math.ceil() on longestStretchNotWriting and totalTimeNotWriting. These are both in seconds, and the update function already runs floor on them, so they should be whole numbers.