### PR TITLE
Fix Colors & Condense SectionTab Styling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,6 @@
 #wordsprint #sprintActionPanel .sprintStart {
 	margin: 0.5rem;
 	background-color: var(--background-modifier-success);
-    color: var(--text-on-accent);
 }
 
 #wordsprint #sprintActionPanel .sprintStop {
@@ -71,12 +70,12 @@
 	margin: 0;
 }
 
-#wordsprint #sectionTab .statsTab.active {
-	background-color: var(--interactive-hover);
+#wordsprint #sectionTab .active {
+	background-color: var(--interactive-accent);
+	color: var(--text-on-accent);
 }
-
-#wordsprint #sectionTab .goalsTab.active {
-	background-color: var(--interactive-hover);
+#wordsprint #sectionTab button:not(.active):not(:hover) {
+	background-color: var(--background-secondary-alt);
 }
 
 /* Stats */
@@ -93,7 +92,8 @@
 }
 
 #wordsprint #sprintViewStats .viewStats {
-    background-color: var(--text-faint);
+	background-color: var(--text-faint);
+	color: var(--text-on-accent);
 }
 
 /* Goals */


### PR DESCRIPTION
- I fixed some of the colors for the buttons as it was hard to see the text on some of the buttons light mode.
- Changed the sectiontab colors as it was a little confusing to see which one was active when the brighter color was the inactive one 😵‍💫 
- Shortened the styling for the sectiontab since the 2 buttons use the same active class

Result:
![CiVLyJAE1t](https://user-images.githubusercontent.com/54087190/139734310-dfc9b2a7-0f32-48cb-b637-7700cf94d733.gif)
