### PR TITLE
Added "Average Words per Hour" to stats modal.

### DIFF
--- a/src/EndOfSprintStatsModal.ts
+++ b/src/EndOfSprintStatsModal.ts
@@ -65,6 +65,12 @@ export default class EndOfSprintStatsModal extends Modal {
 				text.setDisabled(true)
 			})
 		new Setting(contentEl)
+			.setName("Average Words Per Hour")
+			.addText((text) => {
+				text.setValue(`${numeral(this.sprintRunStat.averageWordsPerMinute * 60).format('0.0')}`)
+				text.setDisabled(true)
+			})
+		new Setting(contentEl)
 			.setName("Yellow Notices")
 			.addText((text) => {
 				text.setValue(`${this.sprintRunStat.yellowNotices}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,7 @@ export default class WordSprintPlugin extends Plugin {
 				}
 				statsText += `Total Words Written: ${stats.totalWordsWritten}\n`
 				statsText += `Average Words Per Minute: ${numeral(stats.averageWordsPerMinute).format('0.0')}\n`
+				statsText += `Average Words Per Hour: ${numeral(stats.averageWordsPerMinute * 60).format('0.0')}\n`
 				statsText += `Yellow Notices: ${stats.yellowNotices}\n`
 				statsText += `Red Notices: ${stats.redNotices}\n`
 				statsText += `Longest Stretch Not Writing: ${secondsToHumanize(stats.longestStretchNotWriting)}\n`
@@ -192,6 +193,12 @@ export default class WordSprintPlugin extends Plugin {
 					return total
 				}, 0) / totalSprints
 				statsText += `Average Words per Minute: ${numeral(averageWPM).format('0.00')}\n`
+
+				const averageWPH = this.sprintHistory.reduce((total: number, amount: SprintRunStat, currentIndex : number, array: SprintRunStat[]) => {
+					total += amount.averageWordsPerMinute * 60
+					return total
+				}, 0) / totalSprints
+				statsText += `Average Words per Hour: ${numeral(averageWPH).format('0.00')}\n`
 
 				const redNotices = this.sprintHistory.reduce((total: number, amount: SprintRunStat, currentIndex : number, array: SprintRunStat[]) => {
 					total += amount.redNotices
@@ -247,14 +254,15 @@ export default class WordSprintPlugin extends Plugin {
 				let statsText : string = ''
 
 				statsText += `### Word Sprints Table\n`
-				statsText += '| # | Length | Total Words | Average Words | Yellow Notices | Red Notices | Longest Stretch Not Writing | Total Time Not Writing | Total Words Added | Total Words Deleted | Total Net Words |\n'
-				statsText += '|---|--------|-------------|---------------|----------------|-------------|-----------------------------|------------------------|-------------------|---------------------|-----------------|\n'
+				statsText += '| # | Length | Total Words | Average Words | Avg Words/Hour | Yellow Notices | Red Notices | Longest Stretch Not Writing | Total Time Not Writing | Total Words Added | Total Words Deleted | Total Net Words |\n'
+				statsText += '|---|--------|-------------|---------------|----------------|----------------|-------------|-----------------------------|------------------------|-------------------|---------------------|-----------------|\n'
 
 				this.sprintHistory.forEach((sprint: SprintRunStat, index:number) => {
 					statsText += `| ${index + 1}`
 					statsText += `| ${sprint.sprintLength}`
 					statsText += `| ${sprint.totalWordsWritten}`
 					statsText += `| ${numeral(sprint.averageWordsPerMinute).format('0.0')}`
+					statsText += `| ${numeral(sprint.averageWordsPerMinute * 60).format('0.0')}`
 					statsText += `| ${sprint.yellowNotices}`
 					statsText += `| ${sprint.redNotices}`
 					statsText += `| ${secondsToHumanize(sprint.longestStretchNotWriting)}`


### PR DESCRIPTION
I wanted an Average Words per Hour stat.  It makes use of the existing average words per minute calculation, so no additional values are collected.  The change will work with all existing user stats.  

Submitting a pull request in case you think this would be useful to the rest of the user base.  Thanks!