### PR TITLE
Add feature to track word count across multiple files

### DIFF
--- a/src/SprintRun.spec.ts
+++ b/src/SprintRun.spec.ts
@@ -27,4 +27,62 @@ describe('SprintRun', () => {
 		expect(sprintRun.yellowNoticeTimeout).toEqual(5)
 		expect(sprintRun.redNoticeTimeout).toEqual(10)
 	})
+
+	it("should initialize the fileMetrics property", () => {
+		const sprintRun = new SprintRun(25, 10, 50);
+		expect(sprintRun["fileMetrics"]).toBeInstanceOf(Map);
+		expect(sprintRun["fileMetrics"].size).toBe(0);
+	});
+})
+
+describe("typingUpdate", () => {
+	it("should update the fileMetrics Map with the correct word count", () => {
+		const sprintRun = new SprintRun(25, 10, 50);
+		sprintRun.typingUpdate("Hello world", "file1.md");
+		expect(sprintRun["fileMetrics"].get("file1.md")?.wordCount).toBe(2);
+	});
+
+	it("should update the fileMetrics Map with the correct words added and deleted", () => {
+		const sprintRun = new SprintRun(25, 10, 50);
+		sprintRun.typingUpdate("Hello world", "file1.md");
+		sprintRun.typingUpdate("Hello world lorem ipsum", "file1.md");
+		expect(sprintRun["fileMetrics"].get("file1.md")?.wordsAdded).toBe(4);
+		expect(sprintRun["fileMetrics"].get("file1.md")?.wordsDeleted).toBe(0);
+	});
+
+	it("should handle metrics for multiple files", () => {
+		const sprintRun = new SprintRun(25, 10, 50);
+		sprintRun.typingUpdate("Hello world", "file1.md");
+		sprintRun.typingUpdate("Lorem ipsum", "file2.md");
+		expect(sprintRun["fileMetrics"].size).toBe(2);
+		expect(sprintRun["fileMetrics"].get("file1.md")?.wordCount).toBe(2);
+		expect(sprintRun["fileMetrics"].get("file2.md")?.wordCount).toBe(2);
+	});
+})
+
+describe("getMiniStats and getStats", () => {
+	beforeEach(() => {
+		jest.useFakeTimers();
+	  });
+	  
+	  afterEach(() => {
+		jest.useRealTimers();
+	  });
+	it("should aggregate word count metrics across multiple files", () => {
+		const sprintRun = new SprintRun(25, 10, 50);
+		sprintRun.previousWordCount = 0;
+		sprintRun.typingUpdate("Hello world", "file1.md");
+		sprintRun.typingUpdate("Lorem ipsum", "file2.md");
+		sprintRun.typingUpdate("Hello world lorem ipsum", "file1.md");
+
+		const miniStats = sprintRun.getMiniStats();
+		expect(miniStats.wordCount).toBe(6);
+
+		jest.advanceTimersByTime(1000);
+		const stats = sprintRun.getStats();
+		expect(stats.totalWordsWritten).toBe(6);
+		expect(stats.wordsAdded).toBe(6);
+		expect(stats.wordsDeleted).toBe(0);
+		expect(stats.wordsNet).toBe(6);
+	});
 })

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -1,0 +1,15 @@
+import { FileMetrics } from "./types";
+
+describe("FileMetrics", () => {
+  it("should have the correct properties", () => {
+    const fileMetrics: FileMetrics = {
+      wordCount: 100,
+      wordsAdded: 50,
+      wordsDeleted: 20,
+    };
+
+    expect(fileMetrics.wordCount).toBe(100);
+    expect(fileMetrics.wordsAdded).toBe(50);
+    expect(fileMetrics.wordsDeleted).toBe(20);
+  });
+});

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -6,10 +6,12 @@ describe("FileMetrics", () => {
       wordCount: 100,
       wordsAdded: 50,
       wordsDeleted: 20,
+      netWords: 30,
     };
 
     expect(fileMetrics.wordCount).toBe(100);
     expect(fileMetrics.wordsAdded).toBe(50);
     expect(fileMetrics.wordsDeleted).toBe(20);
+    expect(fileMetrics.netWords).toBe(30);
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,5 @@ export interface FileMetrics {
 	wordCount: number;
 	wordsAdded: number;
 	wordsDeleted: number;
+	netWords: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,3 +36,9 @@ export interface SprintRunStat {
 	wordsDeleted: number,
 	wordsNet: number,
 }
+
+export interface FileMetrics {
+	wordCount: number;
+	wordsAdded: number;
+	wordsDeleted: number;
+}


### PR DESCRIPTION
I've added functionality to make word count correctly track between multiple files when they are opened during a sprint. Previously, it would break if you tried to open a new file during a sprint and it would mess up the total word count stats. Now it should function no matter how many files you open or how many words are in those files. 

This should allow sprints some more flexibility. I find it especially useful when writing as I can work on multiple chapters in a sprint when I finish the one I started on. 

I've mostly made changes in SprintRun.ts. The `typingUpdate` method was rewritten to track what files are being worked on and their individual stats. `getMiniStats` and `getStats` were both updated to use the new information. To facilitate this, I added a new interface to types.ts. 

I've written some tests to make sure the new features don't break anything, though there are some bugs with them that I couldn't figure out. Testing in Obsidian didn't reveal any issues, so I ignored the buggy tests and just looked at the results in production. 

This should close #19.